### PR TITLE
Checkout whole history

### DIFF
--- a/.github/workflows/release-on-milestone-closed.yml
+++ b/.github/workflows/release-on-milestone-closed.yml
@@ -26,6 +26,8 @@ jobs:
     steps:
       - name: "Checkout"
         uses: "actions/checkout@v4"
+        with:
+          fetch-depth: 0
 
       - name: "Release"
         uses: "laminas/automatic-releases@v1"


### PR DESCRIPTION
Shallow checkout prevents git fetch from pulling refs that would require updating `.git/shallow` file. The result is branches are not available in local clone for automatic releases use.

See https://github.com/laminas/automatic-releases/issues/241#issuecomment-1922190914

There is currently another bug prevented by this issue. Do not merge yet.

This has a potential adverse impact on large repositories. Automatic releases workflow is used relatively infrequently not to be an issue. 